### PR TITLE
Implement the last remaining steps so that we can fully support ROOT6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 find_package(ROOT REQUIRED)
 include_directories(${ROOT_INCLUDE_DIR})
 # Create dictionary for headers for ROOT
-message("Generating dictionaries for ROOT ${ROOT_VERSION}...")
+# message("Generating dictionaries for ROOT ${ROOT_VERSION}...")
 # Loop over all found LinkDef.h header files
 set(my_project_linkdefs_files "")
 set(my_project_linkdefs_header_files "")
@@ -50,6 +50,7 @@ foreach( _linkdef ${my_project_linkdefs})
   string(REGEX REPLACE "LinkDef.h" ".hh" _header ${_file})
   string(REGEX REPLACE "LinkDef.h" "" _prefix ${_file})
   set(ROOTPWA_DICTIONARY ${CMAKE_CURRENT_BINARY_DIR}/${_prefix}Dictionary)
+  set(ROOTPCM_DICTIONARY ${ROOTPWA_DICTIONARY}_rdict.pcm)
 ROOT_GENERATE_DICTIONARY(
   "${ROOTPWA_DICTIONARY}"
   "${_header}"
@@ -57,9 +58,10 @@ ROOT_GENERATE_DICTIONARY(
   OPTIONS "-p" ## -p to use compilers preprocessor instead of CINTs preprocessor
   )
 set(my_project_sources_dictionary ${my_project_sources_dictionary} ${ROOTPWA_DICTIONARY})
+set(my_project_dictionary_pcm ${my_project_dictionary_pcm} ${ROOTPCM_DICTIONARY})
 endforeach()
 #set(ROOT_LIBRARIES ${ROOT_LIBRARIES} -lGui)
-message("All project sources: ${my_project_sources_dictionary}")
+#message("All project sources: ${my_project_sources_dictionary}")
 
 # Find Boost libraries
 # There is a bug in CMAke 2.8's internal find boost process
@@ -112,3 +114,7 @@ install (TARGETS ComptonG4_batch DESTINATION bin)
 install (TARGETS ComptonG4Root DESTINATION bin)
 install (TARGETS ComptonG4Lib DESTINATION lib)
 install( FILES ${my_project_headers} DESTINATION include )
+## Install *.pcm (ROOT 6 dictionaries) only for ROOT 6 and above
+if(ROOT_VERSION VERSION_GREATER 5.90)
+  install( FILES ${my_project_dictionary_pcm} DESTINATION lib )
+endif(ROOT_VERSION VERSION_GREATER 5.90)

--- a/ComptonG4Root.cc
+++ b/ComptonG4Root.cc
@@ -7,6 +7,7 @@
 #include <TString.h>
 #include <TRint.h>
 #include <cstdlib>
+#include <iostream>
 
 int main(int argc, char** argv)
 {
@@ -16,8 +17,15 @@ int main(int argc, char** argv)
   TString path = getenv("COMPTONG4");
   // So that it can work with the installed version too
   gROOT->ProcessLine(".include " + path + "/include");
-  gROOT->ProcessLine("gSystem->Load(\"libCint.so\");");
+  // Load either CINT for ROOT5 or less, and cling for ROOT 6 and above
+  if(gROOT->GetVersionInt()<60000) {
+    gROOT->ProcessLine("gSystem->Load(\"libCint.so\");");
+  } else {
+    gROOT->ProcessLine("gSystem->Load(\"libCling.so\");");
+  }
+  // Load the dynamic library for ComptonG4 (this adds all the dictionaries)
   gROOT->ProcessLine("gSystem->Load(\"libComptonG4.so\");");
+
   // Run the interface
   rint->Run();
   // Delete object

--- a/cmake/modules/FindROOT.cmake
+++ b/cmake/modules/FindROOT.cmake
@@ -49,7 +49,15 @@ find_package_handle_standard_args(ROOT DEFAULT_MSG ROOT_CONFIG_EXECUTABLE
 mark_as_advanced(ROOT_CONFIG_EXECUTABLE)
 
 include(CMakeParseArguments)
-find_program(ROOTCINT_EXECUTABLE rootcint PATHS $ENV{ROOTSYS}/bin)
+if(ROOT_VERSION VERSION_LESS 5.90)
+  ## Use rootcint  for ROOT <= 5
+  find_program(ROOTDICT_EXECUTABLE rootcint PATHS $ENV{ROOTSYS}/bin)
+  message("--   Found rootcint")
+else()
+  ## Use rootcling for ROOT >= 6
+  find_program(ROOTDICT_EXECUTABLE rootcling PATHS $ENV{ROOTSYS}/bin)
+  message("--   Found rootcling")
+endif()
 find_program(GENREFLEX_EXECUTABLE genreflex PATHS $ENV{ROOTSYS}/bin)
 find_package(GCCXML)
 
@@ -91,11 +99,19 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     set(linkdefs ${linkdefs} ${linkFile})
     unset(linkFile CACHE)
   endforeach()
-  #---call rootcint------------------------------------------
+  #---call rootcint or rootcling-----------------------------
+if(ROOT_VERSION VERSION_LESS 5.90)
   add_custom_command(OUTPUT ${dictionary}.cxx ${dictionary}.h
-                     COMMAND ${ROOTCINT_EXECUTABLE} -cint -f  ${dictionary}.cxx 
-                                          -c ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${linkdefs} 
-                     DEPENDS ${headerfiles} ${linkdefs} VERBATIM)
+    COMMAND ${ROOTDICT_EXECUTABLE} -cint -f  ${dictionary}.cxx 
+    -c ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${linkdefs} 
+    DEPENDS ${headerfiles} ${linkdefs} VERBATIM)
+else(ROOT_VERSION VERSION_LESS 5.90)
+  add_custom_command(OUTPUT ${dictionary}.cxx ${dictionary}.h
+    COMMAND ${ROOTDICT_EXECUTABLE} -f  ${dictionary}.cxx 
+    -c ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${linkdefs} 
+    DEPENDS ${headerfiles} ${linkdefs} VERBATIM)
+endif(ROOT_VERSION VERSION_LESS 5.90)
+
 endfunction()
 
 #----------------------------------------------------------------------------

--- a/sources/src/ComptonG4Analysis.cc
+++ b/sources/src/ComptonG4Analysis.cc
@@ -134,8 +134,14 @@ int ComptonG4Analysis::DetectorIndex(std::string name)
  */
 void ComptonG4Analysis::Initialize()
 {
+  // Load up CINT or Cling so that we have access to our dictionaries
+  if(gROOT->GetVersionInt()<60000) {
+    gSystem->Load("libCint.so");
+  } else {
+    gSystem->Load("libCling.so");
+  }
+
   // Ask ROOT to load our library
-  gSystem->Load("libCint.so");
   gSystem->Load("libComptonG4.so");
   gROOT->ProcessLine("#include <string>");
   gROOT->ProcessLine("#include <vector>");


### PR DESCRIPTION
This now loads up either CINT or Cling libraries as needed, and the ROOT6
dictionaries are also copied over to the install directory (they are *.pcm
files).

This closes #2.
